### PR TITLE
create middleware to verify token

### DIFF
--- a/server/src/app.js
+++ b/server/src/app.js
@@ -7,6 +7,7 @@ const helmet = require('helmet');
 const cookieParser = require('cookie-parser');
 const swaggerUi = require("swagger-ui-express");
 const swaggerSpec = require("./swaggerConfig");
+const verifyToken = require('./middlewares/verifyToken');
 
 
 const authRoutes = require('./routes/authRoutes');

--- a/server/src/middlewares/verifyToken.js
+++ b/server/src/middlewares/verifyToken.js
@@ -1,0 +1,32 @@
+const jwt = require('jsonwebtoken');
+const { TokenExpiredError, JsonWebTokenError } = require('jsonwebtoken');
+require("dotenv").config();
+
+const verifyToken = (req, res, next) => {
+
+    const token = req.cookies.token || req.headers['authorization']?.split(' ')[1];
+
+    if (!token) {
+        return res.status(403).json({ message: "No token provided" });
+    }
+
+    try {
+        const decoded = jwt.verify(token, process.env.JWT_SECRET);
+
+        req.user = decoded;
+
+        next();
+    } catch (error) {
+
+        if (error instanceof TokenExpiredError) {
+            return res.status(401).json({ message: "Token expired" });
+        } else if (error instanceof JsonWebTokenError) {
+            return res.status(401).json({ message: "Invalid token" });
+        } else {
+            console.error("Token verification error:", error);
+            return res.status(500).json({ message: "Internal server error" });
+        }
+    }
+};
+
+module.exports = verifyToken;


### PR DESCRIPTION
Ajout du middleware pour vérifier si il y a bien un token dans la requête  envoyé par le front et vérifie si on peux bien décoder le token. 

Les routes n'ont pas été sécurisé car on est en http. 